### PR TITLE
Use find_packages() from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
@@ -17,8 +17,5 @@ setup(
 
     author = 'Matthew Tretter',
     author_email = 'matthew@exanimo.com',
-    packages = [
-        'periodically',
-        'exampleapp',
-    ],
+    packages = find_packages()
 )


### PR DESCRIPTION
The current package list doesn't include periodically.managment and
periodically.migrations, so these don't get installed and manage.py
doesn't see the "runtasks" command.

setuptools find_packages() automates finding all the correct
sub-packages
