### PR TITLE
Changed get_query_set to get_queryset for compatibility with Django 1.7 ...

### DIFF
--- a/periodically/models.py
+++ b/periodically/models.py
@@ -3,7 +3,11 @@ from django.db import models
 
 class ExecutionRecordManager(models.Manager):
     def get_most_recent(self, task=None, schedule=None):
-        qs = self.get_queryset().order_by('-start_time').all()
+        if django.VERSION < (1, 7):
+            qs = self.get_query_set().order_by('-start_time').all()
+        else:
+            qs = self.get_queryset().order_by('-start_time').all()
+            
         if task:
             qs = qs.filter(task_id=task.task_id)
         if schedule:

--- a/periodically/models.py
+++ b/periodically/models.py
@@ -3,7 +3,7 @@ from django.db import models
 
 class ExecutionRecordManager(models.Manager):
     def get_most_recent(self, task=None, schedule=None):
-        qs = self.get_query_set().order_by('-start_time').all()
+        qs = self.get_queryset().order_by('-start_time').all()
         if task:
             qs = qs.filter(task_id=task.task_id)
         if schedule:


### PR DESCRIPTION
Fix for error when using Django 1.7 and later.

> Z:\metric\venv\lib\site-packages\periodically\models.py:6: RemovedInDjango18Warning: `BaseManager.get_query_set` is deprecated, use `get_queryset` instead.
>  qs = self.get_query_set().order_by('-start_time').all()
