### PR TITLE
Added utf-8 encoding for MD5 hashlib

### DIFF
--- a/periodically/schedules.py
+++ b/periodically/schedules.py
@@ -23,7 +23,7 @@ class BaseSchedule(object):
         class_name = '%s.%s' % (self.__class__.__module__,
                 self.__class__.__name__)
         time_args = tuple([getattr(self, name) for name in self._time_attrs])
-        return md5(str((class_name, time_args))).hexdigest()
+        return md5(str((class_name, time_args)).encode('utf-8')).hexdigest()
 
     def time_before(self, time):
         kwargs = dict((k, getattr(self, k)) for k in self._time_attrs)


### PR DESCRIPTION
I found the following error while calling django-periodically from the periodicall crontab task:

```
(.venv)rtubiopa@satnet:/etc/cron.d$ source /home/rtubiopa/server_master/.venv/bin/activate && python /home/rtubiopa/server_master/manage.py runtasks
Traceback (most recent call last):
  File "/home/rtubiopa/server_master/manage.py", line 10, in <module>
management.execute_from_command_line(sys.argv)
  File "/home/rtubiopa/server_master/.venv/lib/python3.4/site-packages/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File "/home/rtubiopa/server_master/.venv/lib/python3.4/site-packages/django/core/management/__init__.py", line 377, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/rtubiopa/server_master/.venv/lib/python3.4/site-packages/django/core/management/base.py", line 288, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/rtubiopa/server_master/.venv/lib/python3.4/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/rtubiopa/server_master/.venv/lib/python3.4/site-packages/periodically/management/commands/runtasks.py", line 61, in handle
    backend.run_scheduled_tasks(tasks, fake=fake)
  File "/home/rtubiopa/server_master/.venv/lib/python3.4/site-packages/periodically/backends.py", line 59, in run_scheduled_tasks
    self._run_tasks(tasks, fake, False)
  File "/home/rtubiopa/server_master/.venv/lib/python3.4/site-packages/periodically/backends.py", line 94, in _run_tasks
    if force or get_scheduled_time(task, schedule, now) <= now:
  File "/home/rtubiopa/server_master/.venv/lib/python3.4/site-packages/periodically/utils.py", line 17, in get_scheduled_time
    previous_record = ExecutionRecord.objects.get_most_recent(task, schedule)
  File "/home/rtubiopa/server_master/.venv/lib/python3.4/site-packages/periodically/models.py", line 10, in get_most_recent
    qs = qs.filter(schedule_id=schedule.schedule_id)
  File "/home/rtubiopa/server_master/.venv/lib/python3.4/site-packages/periodically/schedules.py", line 33, in schedule_id
    return md5(str((class_name, time_args))).hexdigest()
TypeError: Unicode-objects must be encoded before hashing
```

In Python 3.4, following the specification for the md5 object within the hashlib, strings must be encoded before passing them to MD5. The suggested patch includes that encoding and fixes this problem.
